### PR TITLE
Feat/15: 사용자 이용 내역 로깅

### DIFF
--- a/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
@@ -113,7 +113,8 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/orders/daily"),
                 antMatcher("/api/v1/orders/daily"),
                 antMatcher("/api/v1/orders/{orderMenuId}/status"),
-                antMatcher("/api/v1/merchant/qr")
+                antMatcher("/api/v1/merchant/qr"),
+                antMatcher("/api/v1/auth/login/history")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
@@ -114,7 +114,9 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/orders/daily"),
                 antMatcher("/api/v1/orders/{orderMenuId}/status"),
                 antMatcher("/api/v1/merchant/qr"),
-                antMatcher("/api/v1/auth/login/history")
+                antMatcher("/api/v1/auth/login/history"),
+                antMatcher("/api/v1/merchant/info"),
+                antMatcher("/api/v1/merchant/tables/{tableId}/status")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/fisa/wonq/member/controller/AuthController.java
+++ b/src/main/java/com/fisa/wonq/member/controller/AuthController.java
@@ -3,15 +3,17 @@ package com.fisa.wonq.member.controller;
 import com.fisa.wonq.global.response.ApiResponse;
 import com.fisa.wonq.global.response.ResponseCode;
 import com.fisa.wonq.global.security.jwt.JwtTokenProvider;
+import com.fisa.wonq.global.security.user.UserDetailsImpl;
 import com.fisa.wonq.member.controller.dto.req.AuthRequestDTO.LoginRequest;
 import com.fisa.wonq.member.controller.dto.res.AuthResponseDTO.LoginResponse;
+import com.fisa.wonq.member.service.LoginHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,12 +26,14 @@ public class AuthController {
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final LoginHistoryService loginHistoryService;
 
     @Operation(summary = "로그인",
             description = "아이디/비밀번호로 인증 후 액세스 토큰을 발급합니다.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
-            @RequestBody LoginRequest req
+            @RequestBody LoginRequest req,
+            HttpServletRequest servletRequest
     ) {
         // 인증 시도
         Authentication authentication = authenticationManager.authenticate(
@@ -37,8 +41,11 @@ public class AuthController {
         );
 
         // Principal(UserDetailsImpl)에서 토큰 생성
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String token = jwtTokenProvider.createAccessToken((com.fisa.wonq.global.security.user.UserDetailsImpl) userDetails);
+        UserDetailsImpl principal = (UserDetailsImpl) authentication.getPrincipal();
+        String token = jwtTokenProvider.createAccessToken(principal);
+
+        // 로그인 이력 기록
+        loginHistoryService.recordLogin(principal.getUserId(), servletRequest);
 
         // 응답
         return ResponseEntity.ok(

--- a/src/main/java/com/fisa/wonq/member/controller/LoginHistoryController.java
+++ b/src/main/java/com/fisa/wonq/member/controller/LoginHistoryController.java
@@ -1,0 +1,39 @@
+package com.fisa.wonq.member.controller;
+
+import com.fisa.wonq.global.response.ApiResponse;
+import com.fisa.wonq.global.response.ResponseCode;
+import com.fisa.wonq.global.security.resolver.Account;
+import com.fisa.wonq.global.security.resolver.CurrentAccount;
+import com.fisa.wonq.member.controller.dto.res.LoginHistoryResponse;
+import com.fisa.wonq.member.service.LoginHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth/login/history")
+@RequiredArgsConstructor
+public class LoginHistoryController {
+
+    private final LoginHistoryService loginHistoryService;
+
+    @GetMapping
+    @Operation(summary = "로그인 이력 조회",
+            description = "현재 로그인된 회원의 로그인 이력을 페이징하여 반환합니다.")
+    public ResponseEntity<ApiResponse<Page<LoginHistoryResponse>>> listLoginHistory(
+            @CurrentAccount Account account,
+            @PageableDefault(size = 20, sort = "loginAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Page<LoginHistoryResponse> page = loginHistoryService
+                .getLoginHistory(account.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, page));
+    }
+}

--- a/src/main/java/com/fisa/wonq/member/controller/LoginHistoryController.java
+++ b/src/main/java/com/fisa/wonq/member/controller/LoginHistoryController.java
@@ -8,10 +8,12 @@ import com.fisa.wonq.member.controller.dto.res.LoginHistoryResponse;
 import com.fisa.wonq.member.service.LoginHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,10 +28,12 @@ public class LoginHistoryController {
 
     @GetMapping
     @Operation(summary = "로그인 이력 조회",
-            description = "현재 로그인된 회원의 로그인 이력을 페이징하여 반환합니다.")
+            description = "현재 로그인된 회원의 로그인 이력을 페이징하여 반환합니다. (기본정렬: loginAt ↓)")
     public ResponseEntity<ApiResponse<Page<LoginHistoryResponse>>> listLoginHistory(
             @CurrentAccount Account account,
-            @PageableDefault(size = 20, sort = "loginAt", direction = Sort.Direction.DESC)
+            @ParameterObject
+            @PageableDefault(size = 20)
+            @SortDefault(sort = "loginAt", direction = Sort.Direction.DESC) // 기본 정렬(loginAt 내림차순)
             Pageable pageable
     ) {
         Page<LoginHistoryResponse> page = loginHistoryService

--- a/src/main/java/com/fisa/wonq/member/controller/dto/res/LoginHistoryResponse.java
+++ b/src/main/java/com/fisa/wonq/member/controller/dto/res/LoginHistoryResponse.java
@@ -1,0 +1,23 @@
+package com.fisa.wonq.member.controller.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "로그인 이력 응답 DTO")
+public class LoginHistoryResponse {
+    @Schema(description = "로그인 일시")
+    private LocalDateTime loginAt;
+
+    @Schema(description = "IP 주소")
+    private String ipAddress;
+
+    @Schema(description = "User-Agent")
+    private String userAgent;
+}

--- a/src/main/java/com/fisa/wonq/member/domain/LoginHistory.java
+++ b/src/main/java/com/fisa/wonq/member/domain/LoginHistory.java
@@ -1,0 +1,32 @@
+package com.fisa.wonq.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "login_history")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LoginHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column
+    private LocalDateTime loginAt;
+
+    @Column
+    private String ipAddress;
+
+    @Column
+    private String userAgent;
+}

--- a/src/main/java/com/fisa/wonq/member/repository/LoginHistoryRepository.java
+++ b/src/main/java/com/fisa/wonq/member/repository/LoginHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.fisa.wonq.member.repository;
+
+import com.fisa.wonq.member.domain.LoginHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginHistoryRepository extends JpaRepository<LoginHistory, Long> {
+    Page<LoginHistory> findByMember_MemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/fisa/wonq/member/service/LoginHistoryService.java
+++ b/src/main/java/com/fisa/wonq/member/service/LoginHistoryService.java
@@ -1,0 +1,58 @@
+package com.fisa.wonq.member.service;
+
+import com.fisa.wonq.global.security.exception.SecurityErrorCode;
+import com.fisa.wonq.global.security.exception.SecurityException;
+import com.fisa.wonq.member.controller.dto.res.LoginHistoryResponse;
+import com.fisa.wonq.member.domain.LoginHistory;
+import com.fisa.wonq.member.domain.Member;
+import com.fisa.wonq.member.domain.enums.MemberStatus;
+import com.fisa.wonq.member.repository.LoginHistoryRepository;
+import com.fisa.wonq.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LoginHistoryService {
+    private final LoginHistoryRepository loginHistoryRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 로그인 성공 시 기록을 남깁니다.
+     */
+    @Transactional
+    public void recordLogin(String accountId, HttpServletRequest request) {
+        Member member = memberRepository.findByAccountIdAndStatusNot(accountId, MemberStatus.DELETED)
+                .orElseThrow(() -> new SecurityException(SecurityErrorCode.UNAUTHORIZED));
+        LoginHistory history = LoginHistory.builder()
+                .member(member)
+                .loginAt(LocalDateTime.now())
+                .ipAddress(request.getRemoteAddr())
+                .userAgent(request.getHeader("User-Agent"))
+                .build();
+        loginHistoryRepository.save(history);
+    }
+
+    /**
+     * 페이징된 로그인 이력 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<LoginHistoryResponse> getLoginHistory(Long memberId, Pageable pageable) {
+        return loginHistoryRepository.findByMember_MemberId(memberId, pageable)
+                .map(this::toDto);
+    }
+
+    private LoginHistoryResponse toDto(LoginHistory h) {
+        return LoginHistoryResponse.builder()
+                .loginAt(h.getLoginAt())
+                .ipAddress(h.getIpAddress())
+                .userAgent(h.getUserAgent())
+                .build();
+    }
+}

--- a/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
@@ -6,6 +6,7 @@ import com.fisa.wonq.global.security.resolver.Account;
 import com.fisa.wonq.global.security.resolver.CurrentAccount;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableRequest;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableStatusRequest;
+import com.fisa.wonq.merchant.controller.dto.req.MerchantInfoUpdateRequest;
 import com.fisa.wonq.merchant.controller.dto.req.QrCodeRequest;
 import com.fisa.wonq.merchant.controller.dto.res.*;
 import com.fisa.wonq.merchant.service.MerchantService;
@@ -104,5 +105,16 @@ public class MerchantController {
                 .qrCodeImageUrl(imageUrl)
                 .build();
         return ResponseEntity.ok(ApiResponse.of(resp));
+    }
+
+    @PatchMapping("/info")
+    @Operation(summary = "가맹점 기본정보 수정",
+            description = "매장 전화번호·소개글·계좌정보를 일부만 수정할 수 있습니다.")
+    public ResponseEntity<ApiResponse<MerchantInfoResponse>> updateMerchantInfo(
+            @CurrentAccount Account account,
+            @Valid @RequestBody MerchantInfoUpdateRequest req
+    ) {
+        MerchantInfoResponse dto = merchantService.updateMerchantInfo(account.id(), req);
+        return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, dto));
     }
 }

--- a/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
@@ -4,10 +4,7 @@ import com.fisa.wonq.global.response.ApiResponse;
 import com.fisa.wonq.global.response.ResponseCode;
 import com.fisa.wonq.global.security.resolver.Account;
 import com.fisa.wonq.global.security.resolver.CurrentAccount;
-import com.fisa.wonq.merchant.controller.dto.req.DiningTableRequest;
-import com.fisa.wonq.merchant.controller.dto.req.DiningTableStatusRequest;
-import com.fisa.wonq.merchant.controller.dto.req.MerchantInfoUpdateRequest;
-import com.fisa.wonq.merchant.controller.dto.req.QrCodeRequest;
+import com.fisa.wonq.merchant.controller.dto.req.*;
 import com.fisa.wonq.merchant.controller.dto.res.*;
 import com.fisa.wonq.merchant.service.MerchantService;
 import com.fisa.wonq.merchant.service.QrService;
@@ -116,5 +113,18 @@ public class MerchantController {
     ) {
         MerchantInfoResponse dto = merchantService.updateMerchantInfo(account.id(), req);
         return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, dto));
+    }
+
+    @PutMapping("/tables/{tableId}")
+    @Operation(summary = "테이블 정보 수정",
+            description = "테이블 번호와 좌석 수를 부분적으로 수정합니다.")
+    public ResponseEntity<ApiResponse<DiningTableUpdateResponse>> updateTableInfo(
+            @CurrentAccount Account account,
+            @PathVariable Long tableId,
+            @Valid @RequestBody DiningTableUpdateRequest req
+    ) {
+        DiningTableUpdateResponse resp =
+                merchantService.updateDiningTableInfo(account.id(), tableId, req);
+        return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, resp));
     }
 }

--- a/src/main/java/com/fisa/wonq/merchant/controller/dto/req/DiningTableUpdateRequest.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/dto/req/DiningTableUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.fisa.wonq.merchant.controller.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "테이블 정보 수정 요청 DTO")
+public class DiningTableUpdateRequest {
+    @Schema(description = "테이블 번호", example = "7")
+    private Integer tableNumber;
+
+    @Schema(description = "좌석 수", example = "6")
+    private Integer capacity;
+}

--- a/src/main/java/com/fisa/wonq/merchant/controller/dto/req/MerchantInfoUpdateRequest.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/dto/req/MerchantInfoUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.fisa.wonq.merchant.controller.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "가맹점 기본정보 수정 요청 DTO")
+public class MerchantInfoUpdateRequest {
+
+    @Schema(description = "매장 전화번호", example = "010-9876-5432")
+    private String merchantOwnerPhoneNo;
+
+    @Schema(description = "매장 소개글", example = "신선한 재료로 만드는 맛집입니다.")
+    private String description;
+
+    @Schema(description = "계좌 은행명", example = "우리은행")
+    private String merchantAccountBankName;
+
+    @Schema(description = "계좌번호", example = "123-456-78901234")
+    private String merchantAccount;
+
+    @Schema(description = "예금주명", example = "홍길동")
+    private String merchantAccountHolderName;
+}

--- a/src/main/java/com/fisa/wonq/merchant/controller/dto/res/DiningTableUpdateResponse.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/dto/res/DiningTableUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.fisa.wonq.merchant.controller.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "테이블 정보 수정 응답 DTO")
+public class DiningTableUpdateResponse {
+    @Schema(description = "테이블 ID", example = "10")
+    private Long diningTableId;
+
+    @Schema(description = "변경된 테이블 번호", example = "7")
+    private Integer tableNumber;
+
+    @Schema(description = "변경된 좌석 수", example = "6")
+    private Integer capacity;
+}

--- a/src/main/java/com/fisa/wonq/merchant/domain/DiningTable.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/DiningTable.java
@@ -51,4 +51,14 @@ public class DiningTable {
     public void setStatus(TableStatus tableStatus) {
         this.status = tableStatus;
     }
+
+    // 일부 필드만 수정
+    public void updateInfo(Integer newTableNumber, Integer newCapacity) {
+        if (newTableNumber != null) {
+            this.tableNumber = newTableNumber;
+        }
+        if (newCapacity != null) {
+            this.capacity = newCapacity;
+        }
+    }
 }

--- a/src/main/java/com/fisa/wonq/merchant/domain/Merchant.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/Merchant.java
@@ -88,4 +88,19 @@ public class Merchant extends BaseDateTimeEntity {
     public void setMember(Member member) {
         this.member = member;
     }
+
+    // 필드 업데이트 메서드
+    public void updateBasicInfo(
+            String phone,
+            String description,
+            String bankName,
+            String account,
+            String holderName
+    ) {
+        if (phone != null) this.merchantOwnerPhoneNo = phone;
+        if (description != null) this.description = description;
+        if (bankName != null) this.merchantAccountBankName = bankName;
+        if (account != null) this.merchantAccount = account;
+        if (holderName != null) this.merchantAccountHolderName = holderName;
+    }
 }

--- a/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
+++ b/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
@@ -4,6 +4,7 @@ package com.fisa.wonq.merchant.service;
 import com.fisa.wonq.global.security.resolver.Account;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableRequest;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableStatusRequest;
+import com.fisa.wonq.merchant.controller.dto.req.MerchantInfoUpdateRequest;
 import com.fisa.wonq.merchant.controller.dto.res.*;
 import com.fisa.wonq.merchant.domain.DiningTable;
 import com.fisa.wonq.merchant.domain.Merchant;
@@ -161,6 +162,35 @@ public class MerchantService {
         return DiningTableStatusResponse.builder()
                 .diningTableId(table.getDiningTableId())
                 .status(table.getStatus())
+                .build();
+    }
+
+    // 가맹점 정보 업데이트
+    @Transactional
+    public MerchantInfoResponse updateMerchantInfo(Long memberId, MerchantInfoUpdateRequest req) {
+        Merchant m = merchantRepository.findByMemberMemberId(memberId)
+                .orElseThrow(() -> new MerchantException(MerchantErrorCode.MERCHANT_NOT_FOUND));
+
+        // 변경된 필드만 엔티티에 반영
+        m.updateBasicInfo(
+                req.getMerchantOwnerPhoneNo(),
+                req.getDescription(),
+                req.getMerchantAccountBankName(),
+                req.getMerchantAccount(),
+                req.getMerchantAccountHolderName()
+        );
+
+        // JPA 더티체킹으로 자동 반영
+        return MerchantInfoResponse.builder()
+                .merchantName(m.getMerchantName())
+                .businessRegistrationNo(m.getBusinessRegistrationNo())
+                .merchantOwnerName(m.getMerchantOwnerName())
+                .merchantOwnerPhoneNo(m.getMerchantOwnerPhoneNo())
+                .merchantAddress(m.getMerchantAddress())
+                .description(m.getDescription())
+                .merchantAccountBankName(m.getMerchantAccountBankName())
+                .merchantAccount(m.getMerchantAccount())
+                .merchantAccountHolderName(m.getMerchantAccountHolderName())
                 .build();
     }
 }

--- a/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
+++ b/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
@@ -4,6 +4,7 @@ package com.fisa.wonq.merchant.service;
 import com.fisa.wonq.global.security.resolver.Account;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableRequest;
 import com.fisa.wonq.merchant.controller.dto.req.DiningTableStatusRequest;
+import com.fisa.wonq.merchant.controller.dto.req.DiningTableUpdateRequest;
 import com.fisa.wonq.merchant.controller.dto.req.MerchantInfoUpdateRequest;
 import com.fisa.wonq.merchant.controller.dto.res.*;
 import com.fisa.wonq.merchant.domain.DiningTable;
@@ -191,6 +192,29 @@ public class MerchantService {
                 .merchantAccountBankName(m.getMerchantAccountBankName())
                 .merchantAccount(m.getMerchantAccount())
                 .merchantAccountHolderName(m.getMerchantAccountHolderName())
+                .build();
+    }
+
+    // 테이블 정보 수정
+    @Transactional
+    public DiningTableUpdateResponse updateDiningTableInfo(
+            Long memberId,
+            Long tableId,
+            DiningTableUpdateRequest req
+    ) {
+        // 권한이 확인된 테이블만 조회
+        DiningTable table = diningTableRepository
+                .findByDiningTableIdAndMerchant_Member_MemberId(tableId, memberId)
+                .orElseThrow(() -> new MerchantException(MerchantErrorCode.TABLE_NOT_FOUND));
+
+        // 변경된 값만 덮어쓰기
+        table.updateInfo(req.getTableNumber(), req.getCapacity());
+
+        // JPA 더티체킹으로 자동 저장
+        return DiningTableUpdateResponse.builder()
+                .diningTableId(table.getDiningTableId())
+                .tableNumber(table.getTableNumber())
+                .capacity(table.getCapacity())
                 .build();
     }
 }


### PR DESCRIPTION
# 🤖 기능 개요
<!-- 이슈에 할당된 기능이 무엇인지 간략하게 한 줄로 적습니다 -->
사용자의 서비스 활동 내역을 로깅하고 조회할 수 있는 API를 구현합니다.

## ✅ Todo
- [x] 가맹점주 활동 이력 조회
- [x] 로그인 내역 조회

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
