### PR TITLE
Fix/22: 주문 생성 및 결제 사전 준비 API 수정

### DIFF
--- a/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
@@ -135,7 +135,8 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/auth/checkAccountId"),
                 antMatcher("/api/v1/auth/login"),
                 antMatcher("/api/v1/merchant/image"),
-                antMatcher("/api/v1/merchant/menus/{merchantId}/list")
+                antMatcher("/api/v1/merchant/menus/{merchantId}/list"),
+                antMatcher("/api/v1/orders/prepare")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
@@ -137,7 +137,8 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/merchant/image"),
                 antMatcher("/api/v1/merchant/menus/{merchantId}/list"),
                 antMatcher("/api/v1/orders/prepare"),
-                antMatcher("/api/v1/merchant/{merchantId}/overview")
+                antMatcher("/api/v1/merchant/{merchantId}/overview"),
+                antMatcher("/api/v1/orders/code/{orderCode}")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/fisa/wonq/global/security/config/WebSecurityConfig.java
@@ -136,7 +136,8 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/auth/login"),
                 antMatcher("/api/v1/merchant/image"),
                 antMatcher("/api/v1/merchant/menus/{merchantId}/list"),
-                antMatcher("/api/v1/orders/prepare")
+                antMatcher("/api/v1/orders/prepare"),
+                antMatcher("/api/v1/merchant/{merchantId}/overview")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/MerchantController.java
@@ -127,4 +127,16 @@ public class MerchantController {
                 merchantService.updateDiningTableInfo(account.id(), tableId, req);
         return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, resp));
     }
+
+    @GetMapping("/{merchantId}/overview")
+    @Operation(
+            summary = "가맹점 대표 이미지·이름 조회(비회원용)",
+            description = "merchantId로 해당 가맹점의 이름과 대표 이미지 URL을 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<MerchantOverviewResponse>> getMerchantOverview(
+            @PathVariable Long merchantId
+    ) {
+        MerchantOverviewResponse dto = merchantService.getMerchantOverview(merchantId);
+        return ResponseEntity.ok(ApiResponse.of(dto));
+    }
 }

--- a/src/main/java/com/fisa/wonq/merchant/controller/dto/res/MerchantOverviewResponse.java
+++ b/src/main/java/com/fisa/wonq/merchant/controller/dto/res/MerchantOverviewResponse.java
@@ -1,0 +1,21 @@
+package com.fisa.wonq.merchant.controller.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "가맹점 기본정보(대표 이미지 + 이름) 조회 응답 DTO")
+public class MerchantOverviewResponse {
+    @Schema(description = "가맹점 ID", example = "10")
+    private Long merchantId;
+
+    @Schema(description = "가맹점 이름", example = "홍콩반점")
+    private String merchantName;
+
+    @Schema(description = "대표 이미지 URL", example = "https://won-q-order-merchant.s3.ap-northeast-2.amazonaws.com/abc123.png")
+    private String merchantImgUrl;
+}

--- a/src/main/java/com/fisa/wonq/merchant/domain/DiningTable.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/DiningTable.java
@@ -4,6 +4,8 @@ import com.fisa.wonq.merchant.domain.enums.TableStatus;
 import com.fisa.wonq.order.domain.Order;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.List;
 
@@ -41,6 +43,7 @@ public class DiningTable {
     private Merchant merchant;
 
     @OneToMany(mappedBy = "diningTable", cascade = CascadeType.ALL)
+    @Fetch(FetchMode.SUBSELECT)
     private List<Order> orders;
 
     // 테이블 상태 변경

--- a/src/main/java/com/fisa/wonq/merchant/domain/Menu.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/Menu.java
@@ -3,6 +3,8 @@ package com.fisa.wonq.merchant.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,10 +48,12 @@ public class Menu {
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<MenuOptionGroup> optionGroups = new ArrayList<>();
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<MenuOption> options = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/merchant/domain/MenuOption.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/MenuOption.java
@@ -3,6 +3,8 @@ package com.fisa.wonq.merchant.domain;
 import com.fisa.wonq.order.domain.OrderMenuOption;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +39,7 @@ public class MenuOption {
 
     @OneToMany(mappedBy = "menuOption", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<OrderMenuOption> orderMenuOptions = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/merchant/domain/MenuOptionGroup.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/MenuOptionGroup.java
@@ -2,6 +2,8 @@ package com.fisa.wonq.merchant.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +36,7 @@ public class MenuOptionGroup {
 
     @OneToMany(mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<MenuOption> options = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/merchant/domain/Merchant.java
+++ b/src/main/java/com/fisa/wonq/merchant/domain/Merchant.java
@@ -5,6 +5,8 @@ import com.fisa.wonq.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,10 +73,12 @@ public class Merchant extends BaseDateTimeEntity {
     private Member member;
 
     @OneToMany(mappedBy = "merchant", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Fetch(FetchMode.SUBSELECT)
     private List<DiningTable> tables = new ArrayList<>();
 
     @OneToMany(mappedBy = "merchant", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<Menu> menus = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/merchant/repository/DiningTableRepository.java
+++ b/src/main/java/com/fisa/wonq/merchant/repository/DiningTableRepository.java
@@ -14,4 +14,6 @@ public interface DiningTableRepository extends JpaRepository<DiningTable, Long> 
      * 없으면 Optional.empty().
      */
     Optional<DiningTable> findByDiningTableIdAndMerchant_Member_MemberId(Long tableId, Long memberId);
+
+    Optional<DiningTable> findByDiningTableId(Long diningTableId);
 }

--- a/src/main/java/com/fisa/wonq/merchant/repository/MerchantRepository.java
+++ b/src/main/java/com/fisa/wonq/merchant/repository/MerchantRepository.java
@@ -9,14 +9,13 @@ import java.util.Optional;
 
 @Repository
 public interface MerchantRepository extends JpaRepository<Merchant, Long> {
+
     /**
-     * 매장 내 모든 테이블·주문·주문메뉴·옵션까지 한 번에 fetch 할 때 사용
+     * 매장 내 모든 테이블만 한 번에 JOIN FETCH 하고,
+     * 각 테이블의 orders는 @Fetch(SUBSELECT)에 의해 별도 쿼리로 로딩됩니다.
      */
     @EntityGraph(attributePaths = {
-            "tables",
-            "tables.orders",
-            "tables.orders.orderMenus",
-            "tables.orders.orderMenus.orderMenuOptions"
+            "tables"
     })
     Optional<Merchant> findWithTablesAndOrdersByMemberMemberId(Long memberId);
 

--- a/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
+++ b/src/main/java/com/fisa/wonq/merchant/service/MerchantService.java
@@ -218,4 +218,16 @@ public class MerchantService {
                 .capacity(table.getCapacity())
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public MerchantOverviewResponse getMerchantOverview(Long merchantId) {
+        Merchant m = merchantRepository.findById(merchantId)
+                .orElseThrow(() -> new MerchantException(MerchantErrorCode.MERCHANT_NOT_FOUND));
+
+        return MerchantOverviewResponse.builder()
+                .merchantId(m.getMerchantId())
+                .merchantName(m.getMerchantName())
+                .merchantImgUrl(m.getMerchantImg())
+                .build();
+    }
 }

--- a/src/main/java/com/fisa/wonq/order/controller/OrderController.java
+++ b/src/main/java/com/fisa/wonq/order/controller/OrderController.java
@@ -98,5 +98,17 @@ public class OrderController {
         orderService.changeOrderMenuStatus(account.id(), orderMenuId, req.getStatus());
         return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS));
     }
+
+    @GetMapping("/code/{orderCode}")
+    @Operation(
+            summary = "주문 코드로 주문 내역 조회",
+            description = "orderCode를 받아 그 주문의 메뉴·옵션·결제 정보를 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getByCode(
+            @PathVariable String orderCode
+    ) {
+        OrderDetailResponse dto = orderService.getOrderByCode(orderCode);
+        return ResponseEntity.ok(ApiResponse.of(dto));
+    }
 }
 

--- a/src/main/java/com/fisa/wonq/order/controller/OrderController.java
+++ b/src/main/java/com/fisa/wonq/order/controller/OrderController.java
@@ -5,8 +5,10 @@ import com.fisa.wonq.global.response.ResponseCode;
 import com.fisa.wonq.global.security.resolver.Account;
 import com.fisa.wonq.global.security.resolver.CurrentAccount;
 import com.fisa.wonq.order.controller.dto.req.ChangeOrderMenuStatusRequest;
+import com.fisa.wonq.order.controller.dto.req.OrderPrepareRequest;
 import com.fisa.wonq.order.controller.dto.req.OrderRequest;
 import com.fisa.wonq.order.controller.dto.res.OrderDetailResponse;
+import com.fisa.wonq.order.controller.dto.res.OrderPrepareResponse;
 import com.fisa.wonq.order.controller.dto.res.OrderResponse;
 import com.fisa.wonq.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +38,16 @@ public class OrderController {
     ) {
         OrderResponse resp = orderService.createOrder(request);
         return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, resp));
+    }
+
+    @PostMapping("/prepare")
+    @Operation(summary = "결제 준비(주문 생성 - 주문 대기 상태)",
+            description = "주문 정보를 ORDERED/PENDING 상태로 저장하고, 결제 요청에 필요한 데이터를 반환합니다.")
+    public ResponseEntity<ApiResponse<OrderPrepareResponse>> prepareOrder(
+            @RequestBody OrderPrepareRequest req
+    ) {
+        OrderPrepareResponse resp = orderService.prepareOrder(req);
+        return ResponseEntity.ok(ApiResponse.of(resp));
     }
 
     @GetMapping("/daily")

--- a/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
+++ b/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
@@ -1,5 +1,6 @@
 package com.fisa.wonq.order.controller.dto.req;
 
+import com.fisa.wonq.order.domain.enums.PaymentMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -12,11 +13,14 @@ import java.util.List;
 @Builder
 @Schema(description = "결제 준비 요청 DTO")
 public class OrderPrepareRequest {
-    @Schema(description = "테이블 ID", example = "3", required = true)
+    @Schema(description = "테이블 ID", example = "1", required = true)
     private Long tableId;
 
     @Schema(description = "주문할 메뉴 목록", required = true)
     private List<OrderMenu> menus;
+
+    @Schema(description = "결제 수단(ENUM - CARD / CASH)", example = "CARD")
+    private PaymentMethod paymentMethod;
 
     @Getter
     @Setter

--- a/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
+++ b/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
@@ -1,0 +1,37 @@
+package com.fisa.wonq.order.controller.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "결제 준비 요청 DTO")
+public class OrderPrepareRequest {
+    @Schema(description = "테이블 ID", example = "3", required = true)
+    private Long tableId;
+
+    @Schema(description = "주문할 메뉴 목록", required = true)
+    private List<OrderMenu> menus;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "주문-메뉴 정보 (inner)")
+    public static class OrderMenu {
+        @Schema(description = "메뉴 ID", example = "42", required = true)
+        private Long menuId;
+
+        @Schema(description = "수량", example = "2", required = true)
+        private Integer quantity;
+
+        @Schema(description = "선택된 옵션 ID 목록", example = "[5,6]")
+        private List<Long> optionIds;
+    }
+}

--- a/src/main/java/com/fisa/wonq/order/controller/dto/res/OrderPrepareResponse.java
+++ b/src/main/java/com/fisa/wonq/order/controller/dto/res/OrderPrepareResponse.java
@@ -1,0 +1,33 @@
+package com.fisa.wonq.order.controller.dto.res;
+
+import com.fisa.wonq.order.domain.enums.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "결제 준비 응답 DTO")
+public class OrderPrepareResponse {
+    @Schema(description = "주문 PK ID", example = "123")
+    private Long orderId;
+
+    @Schema(description = "가맹점 ID", example = "10")
+    private Long merchantId;
+
+    @Schema(description = "테이블 ID", example = "3")
+    private Long tableId;
+
+    @Schema(description = "주문 생성 일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "주문 상태", example = "ORDERED")
+    private OrderStatus orderStatus;
+
+    @Schema(description = "총 주문 금액", example = "45000")
+    private Integer totalAmount;
+}

--- a/src/main/java/com/fisa/wonq/order/controller/dto/res/OrderPrepareResponse.java
+++ b/src/main/java/com/fisa/wonq/order/controller/dto/res/OrderPrepareResponse.java
@@ -13,8 +13,8 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(description = "결제 준비 응답 DTO")
 public class OrderPrepareResponse {
-    @Schema(description = "주문 PK ID", example = "123")
-    private Long orderId;
+    @Schema(description = "고유 주문 코드")
+    private String orderCode;
 
     @Schema(description = "가맹점 ID", example = "10")
     private Long merchantId;

--- a/src/main/java/com/fisa/wonq/order/domain/Order.java
+++ b/src/main/java/com/fisa/wonq/order/domain/Order.java
@@ -7,6 +7,8 @@ import com.fisa.wonq.order.domain.enums.PaymentMethod;
 import com.fisa.wonq.order.domain.enums.PaymentStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -16,19 +18,18 @@ import java.util.List;
  * 주문
  */
 @Entity
-@Table(name = "order")
+@Table(name = "orders")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Order extends BaseDateTimeEntity {
 
-    // 1) 1씩 증가하는 숫자 PK
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 2) 클라이언트/PG 표시용 유니크 코드
+    // 클라이언트/PG 결제용 유니크 코드
     @Column(name = "order_code", nullable = false, updatable = false, unique = true)
     private String orderCode;
 
@@ -55,6 +56,7 @@ public class Order extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @Fetch(FetchMode.SUBSELECT)
     private List<OrderMenu> orderMenus = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/order/domain/Order.java
+++ b/src/main/java/com/fisa/wonq/order/domain/Order.java
@@ -16,7 +16,7 @@ import java.util.List;
  * 주문
  */
 @Entity
-@Table(name = "orders")
+@Table(name = "order")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/fisa/wonq/order/domain/Order.java
+++ b/src/main/java/com/fisa/wonq/order/domain/Order.java
@@ -55,8 +55,8 @@ public class Order extends BaseDateTimeEntity {
     private DiningTable diningTable;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
     @Fetch(FetchMode.SUBSELECT)
+    @Builder.Default
     private List<OrderMenu> orderMenus = new ArrayList<>();
 
     /**

--- a/src/main/java/com/fisa/wonq/order/domain/OrderMenu.java
+++ b/src/main/java/com/fisa/wonq/order/domain/OrderMenu.java
@@ -5,6 +5,8 @@ import com.fisa.wonq.merchant.domain.Menu;
 import com.fisa.wonq.order.domain.enums.OrderMenuStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +48,7 @@ public class OrderMenu extends BaseDateTimeEntity {
     private Order order;
 
     @OneToMany(mappedBy = "orderMenu", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<OrderMenuOption> orderMenuOptions = new ArrayList<>();
 

--- a/src/main/java/com/fisa/wonq/order/repository/OrderRepository.java
+++ b/src/main/java/com/fisa/wonq/order/repository/OrderRepository.java
@@ -47,4 +47,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
                 memberId, from, to, min, max, pageable
         );
     }
+
+    /**
+     * orderMenus만 join fetch, 옵션은 SUBSELECT로 로딩
+     */
+    @EntityGraph(attributePaths = {
+            "orderMenus"
+    })
+    Optional<Order> findWithDetailsByOrderCode(String orderCode);
 }

--- a/src/main/java/com/fisa/wonq/order/service/OrderService.java
+++ b/src/main/java/com/fisa/wonq/order/service/OrderService.java
@@ -302,4 +302,12 @@ public class OrderService {
                 })
                 .sum();
     }
+
+    @Transactional(readOnly = true)
+    public OrderDetailResponse getOrderByCode(String orderCode) {
+        Order order = orderRepo
+                .findWithDetailsByOrderCode(orderCode)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid orderCode: " + orderCode));
+        return toDto(order);  // 기존에 정의된 변환 메서드
+    }
 }

--- a/src/main/java/com/fisa/wonq/order/service/OrderService.java
+++ b/src/main/java/com/fisa/wonq/order/service/OrderService.java
@@ -27,6 +27,7 @@ import com.fisa.wonq.order.domain.enums.PaymentStatus;
 import com.fisa.wonq.order.repository.OrderMenuRepository;
 import com.fisa.wonq.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderService {
@@ -240,6 +242,9 @@ public class OrderService {
                 .totalAmount(totalAmount)
                 .diningTable(table)
                 .build();
+
+        log.debug("Preparing order: table={}, items={}, paymentMethod={}",
+                req.getTableId(), req.getMenus().size(), req.getPaymentMethod());
 
         // 4) 메뉴·옵션 매핑
         for (OrderPrepareRequest.OrderMenu omReq : req.getMenus()) {

--- a/src/main/java/com/fisa/wonq/order/service/OrderService.java
+++ b/src/main/java/com/fisa/wonq/order/service/OrderService.java
@@ -12,14 +12,18 @@ import com.fisa.wonq.merchant.exception.MerchantException;
 import com.fisa.wonq.merchant.repository.DiningTableRepository;
 import com.fisa.wonq.merchant.repository.MenuOptionRepository;
 import com.fisa.wonq.merchant.repository.MenuRepository;
+import com.fisa.wonq.order.controller.dto.req.OrderPrepareRequest;
 import com.fisa.wonq.order.controller.dto.req.OrderRequest;
 import com.fisa.wonq.order.controller.dto.res.OrderDetailResponse;
+import com.fisa.wonq.order.controller.dto.res.OrderPrepareResponse;
 import com.fisa.wonq.order.controller.dto.res.OrderResponse;
 import com.fisa.wonq.order.domain.Order;
 import com.fisa.wonq.order.domain.OrderMenu;
 import com.fisa.wonq.order.domain.OrderMenuOption;
 import com.fisa.wonq.order.domain.PaymentResult;
 import com.fisa.wonq.order.domain.enums.OrderMenuStatus;
+import com.fisa.wonq.order.domain.enums.OrderStatus;
+import com.fisa.wonq.order.domain.enums.PaymentStatus;
 import com.fisa.wonq.order.repository.OrderMenuRepository;
 import com.fisa.wonq.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -211,5 +216,85 @@ public class OrderService {
         }
 
         om.setStatus(newStatus);
+    }
+
+    @Transactional
+    public OrderPrepareResponse prepareOrder(OrderPrepareRequest req) {
+        // 1) 테이블 존재 확인 (상태 변경 없음)
+        DiningTable table = tableRepo.findByDiningTableId(req.getTableId())
+                .orElseThrow(() -> new MerchantException(MerchantErrorCode.TABLE_NOT_FOUND));
+
+        // 2) 총 금액 계산
+        int totalAmount = calculateTotal(req.getMenus());
+
+        // 3) Order 생성 (ORDERED + PENDING)
+        String orderCode = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyMMdd'T'HHmmss"))
+                + "_t" + table.getTableNumber();
+
+        Order order = Order.builder()
+                .orderCode(orderCode)
+                .orderStatus(OrderStatus.ORDERED)
+                .paymentMethod(req.getPaymentMethod())
+                .paymentStatus(PaymentStatus.PENDING)
+                .totalAmount(totalAmount)
+                .diningTable(table)
+                .build();
+
+        // 4) 메뉴·옵션 매핑
+        for (OrderPrepareRequest.OrderMenu omReq : req.getMenus()) {
+            var menu = menuRepo.findById(omReq.getMenuId())
+                    .orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+
+            OrderMenu om = OrderMenu.builder()
+                    .menu(menu)
+                    .quantity(omReq.getQuantity())
+                    .unitPrice(menu.getPrice())
+                    .totalPrice(menu.getPrice() * omReq.getQuantity())
+                    .build();
+
+            if (omReq.getOptionIds() != null) {
+                for (Long optId : omReq.getOptionIds()) {
+                    var mo = menuOptionRepo.findById(optId)
+                            .orElseThrow(() -> new MerchantException(MerchantErrorCode.OPTION_NOT_FOUND));
+                    OrderMenuOption omo = OrderMenuOption.builder()
+                            .menuOption(mo)
+                            .optionPrice(mo.getOptionPrice())
+                            .build();
+                    om.addOption(omo);
+                    om.setTotalPrice(om.getTotalPrice() + mo.getOptionPrice());
+                }
+            }
+            order.addOrderMenu(om);
+        }
+
+        // 5) 저장
+        Order saved = orderRepo.save(order);
+
+        // 6) 응답 반환
+        return OrderPrepareResponse.builder()
+                .orderCode(saved.getOrderCode())
+                .merchantId(saved.getDiningTable().getMerchant().getMerchantId())
+                .tableId(saved.getDiningTable().getDiningTableId())
+                .createdAt(saved.getCreatedAt())
+                .orderStatus(saved.getOrderStatus())
+                .totalAmount(saved.getTotalAmount())
+                .build();
+    }
+
+    private int calculateTotal(List<OrderPrepareRequest.OrderMenu> menus) {
+        return menus.stream()
+                .mapToInt(om -> {
+                    int sum = menuRepo.findById(om.getMenuId())
+                            .orElseThrow().getPrice() * om.getQuantity();
+                    if (om.getOptionIds() != null) {
+                        for (Long optId : om.getOptionIds()) {
+                            sum += menuOptionRepo.findById(optId)
+                                    .orElseThrow().getOptionPrice();
+                        }
+                    }
+                    return sum;
+                })
+                .sum();
     }
 }


### PR DESCRIPTION
> 현재 주문생성(결제) API 분리

결제 준비 API -> `PENDING` 상태로 두고나서
나중에 결제 정상적으로 되었을 경우, 다시 클라이언트의 결제 검증 API 호출 시 `PAID`로 변경

* 기타 자잘한 조회 API 추가해뒀습니다.(자세한 내용은 세부 커밋 확인)