### PR TITLE
Fix:33 가맹점 주문 일별,월별 조회시  MultipleBagFetchException 해결

### DIFF
--- a/src/main/java/com/fisa/wonq/merchant/repository/DiningTableRepository.java
+++ b/src/main/java/com/fisa/wonq/merchant/repository/DiningTableRepository.java
@@ -17,5 +17,7 @@ public interface DiningTableRepository extends JpaRepository<DiningTable, Long> 
 
     Optional<DiningTable> findByDiningTableId(Long diningTableId);
 
+    Optional<DiningTable> findByMerchant_MerchantIdAndTableNumber(Long merchantId, Integer tableNumber);
+
     boolean existsByMerchant_Member_MemberIdAndTableNumber(Long memberId, Integer tableNumber);
 }

--- a/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
+++ b/src/main/java/com/fisa/wonq/order/controller/dto/req/OrderPrepareRequest.java
@@ -16,6 +16,9 @@ public class OrderPrepareRequest {
     @Schema(description = "테이블 ID", example = "1", required = true)
     private Long tableId;
 
+    @Schema(description = "가맹점 ID", example = "1", required = true)
+    private Long merchantId;
+
     @Schema(description = "주문할 메뉴 목록", required = true)
     private List<OrderMenu> menus;
 

--- a/src/main/java/com/fisa/wonq/order/repository/OrderRepository.java
+++ b/src/main/java/com/fisa/wonq/order/repository/OrderRepository.java
@@ -19,8 +19,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @EntityGraph(attributePaths = {
             "orderMenus",
             "orderMenus.menu",
-            "orderMenus.orderMenuOptions",
-            "orderMenus.orderMenuOptions.menuOption",
             "diningTable"
     })
     Page<Order> findByDiningTable_Merchant_Member_MemberIdAndCreatedAtBetweenAndTotalAmountBetween(
@@ -40,7 +38,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             Integer maxAmount,
             Pageable pageable
     ) {
-        // null 처리: minAmount가 없으면 0, maxAmount가 없으면 Integer.MAX_VALUE
         int min = minAmount != null ? minAmount : 0;
         int max = maxAmount != null ? maxAmount : Integer.MAX_VALUE;
         return findByDiningTable_Merchant_Member_MemberIdAndCreatedAtBetweenAndTotalAmountBetween(

--- a/src/main/java/com/fisa/wonq/order/service/OrderService.java
+++ b/src/main/java/com/fisa/wonq/order/service/OrderService.java
@@ -37,6 +37,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -140,10 +141,14 @@ public class OrderService {
         LocalDateTime start = date.atStartOfDay();
         LocalDateTime end = date.plusDays(1).atStartOfDay().minusNanos(1);
 
-        return orderRepo
-                .findByMerchantAndCreatedAtBetweenAndAmountRange(memberId, start, end, minAmount, maxAmount, pageable)
-                .map(this::toDto);
+
+        Page<Order> page = orderRepo.findByMerchantAndCreatedAtBetweenAndAmountRange(
+                memberId, start, end, minAmount, maxAmount, pageable
+        );
+
+        return page.map(this::toDto);
     }
+
 
     /**
      * 해당 연·월(1일 00:00 ~ 말일 23:59:59) 주문 조회
@@ -167,15 +172,21 @@ public class OrderService {
     }
 
     private OrderDetailResponse toDto(Order order) {
+
+
         var menus = order.getOrderMenus().stream().map(om -> {
+            // 옵션 수 확인
             var opts = om.getOrderMenuOptions().stream()
-                    .map(o -> OrderDetailResponse.OrderMenuOptionResponse.builder()
-                            .orderMenuOptionId(o.getOrderMenuOptionId())
-                            .menuOptionId(o.getMenuOption().getMenuOptionId())
-                            .optionName(o.getMenuOption().getOptionName())
-                            .optionPrice(o.getOptionPrice())
-                            .build())
-                    .toList();
+                    .map(o -> {
+                        return OrderDetailResponse.OrderMenuOptionResponse.builder()
+                                .orderMenuOptionId(o.getOrderMenuOptionId())
+                                .menuOptionId(o.getMenuOption().getMenuOptionId())
+                                .optionName(o.getMenuOption().getOptionName())
+                                .optionPrice(o.getOptionPrice())
+                                .build();
+                    })
+                    .collect(Collectors.toList());
+
             return OrderDetailResponse.OrderMenuResponse.builder()
                     .orderMenuId(om.getOrderMenuId())
                     .menuId(om.getMenu().getMenuId())
@@ -186,7 +197,7 @@ public class OrderService {
                     .status(om.getStatus())
                     .options(opts)
                     .build();
-        }).toList();
+        }).collect(Collectors.toList());
 
         return OrderDetailResponse.builder()
                 .orderCode(order.getOrderCode())
@@ -223,7 +234,7 @@ public class OrderService {
     @Transactional
     public OrderPrepareResponse prepareOrder(OrderPrepareRequest req) {
         // 1) 테이블 존재 확인 (상태 변경 없음)
-        DiningTable table = tableRepo.findByDiningTableId(req.getTableId())
+        DiningTable table = tableRepo.findByMerchant_MerchantIdAndTableNumber(req.getMerchantId(), req.getTableId().intValue())
                 .orElseThrow(() -> new MerchantException(MerchantErrorCode.TABLE_NOT_FOUND));
 
         // 2) 총 금액 계산
@@ -243,8 +254,7 @@ public class OrderService {
                 .diningTable(table)
                 .build();
 
-        log.debug("Preparing order: table={}, items={}, paymentMethod={}",
-                req.getTableId(), req.getMenus().size(), req.getPaymentMethod());
+
 
         // 4) 메뉴·옵션 매핑
         for (OrderPrepareRequest.OrderMenu omReq : req.getMenus()) {


### PR DESCRIPTION
# 🚀 개요
<!-- 가맹점 주문 내역 조회 시 MultipleBagFetchException 해결 -->

# 🔨 수정이 필요한 부분

## 문제 1: 주문 상세 조회 시 `N+1` 및 `MultipleBagFetchException` 발생

기존 코드에서는 `@EntityGraph`를 통해 아래 관계들을 한 번의 쿼리로 Fetch Join하려 했습니다.

- `orderMenus`
- `orderMenus.menu`
- `orderMenus.orderMenuOptions`
- `orderMenus.orderMenuOptions.menuOption`
- `diningTable`

하지만 JPA에서는 같은 루트 엔티티에서 **두 개 이상의 컬렉션을 동시에 Fetch Join**하면 `MultipleBagFetchException`이 발생합니다.

MultipleBagFetchException: cannot simultaneously fetch multiple bags


### ✅ 해결 방법

- `@EntityGraph`의 fetch 대상을 **두 단계로 나누어 조회**
  - 1차: `orderMenus`, `orderMenus.menu`, `diningTable`
  - 2차: `orderMenuOptions`, `menuOption`은 `SUBSELECT` 또는 지연 로딩으로 처리

---

## 문제 2: DiningTable ID 중복으로 인한 잘못된 주문 테이블 매핑

기존에는 클라이언트가 보낸 `tableId`만으로 `DiningTable`을 조회했기 때문에,
다른 가맹점이 같은 테이블 번호를 사용할 경우 **먼저 조회된 다른 가맹점의 테이블이 잘못 매핑**되는 문제가 있었습니다.

### 예시

- 가맹점 ID: 5번, 테이블 번호: 2번 주문 요청
- DB에 가맹점 3번도 테이블 번호 2번을 가짐
- → `dining_table_id = 2`가 매핑되어 잘못된 주문 생성

### ✅ 해결 방법

- 주문 생성 요청 시 **`merchantId`도 함께 전달**
- `DiningTable`을 다음과 같이 조회하도록 변경:

```java
DiningTable table = tableRepo.findByMerchant_MerchantIdAndTableNumber(
    req.getMerchantId(), req.getTableId()
).orElseThrow(() -> new MerchantException(MerchantErrorCode.TABLE_NOT_FOUND));
merchantId + tableNumber 조합으로 정확한 DiningTable 매핑 보장
